### PR TITLE
修改逻辑描述错误

### DIFF
--- a/go-basics.tex
+++ b/go-basics.tex
@@ -589,7 +589,7 @@ func unhex(c byte) byte {
     return 0
 }
 \end{lstlisting}
-它匹配失败后不会自动向下尝试，但是可以使用
+它匹配成功后不会自动向下尝试，但是可以使用
 \first{\key{fallthrough}}{keyword!fallthrough}
 使其这样做。
 没有~\key{fallthrough}：


### PR DESCRIPTION
当i == 0时，匹配case 0并执行该条件下的逻辑，然后跳出；使用fallthrough可以向下尝试，即case 1